### PR TITLE
Add property to show images in all modules

### DIFF
--- a/modules/nubo_ear/nubo-ear-detector/CMakeLists.txt
+++ b/modules/nubo_ear/nubo-ear-detector/CMakeLists.txt
@@ -28,10 +28,12 @@ if (${_len} GREATER 2)
 endif ()
 
 find_package(PkgConfig)
+include (GenericFind)
 
 set (GST_REQUIRED 1.3.3)
 set (GLIB_REQUIRED 2.38)
 set (OPENCV_REQUIRED 2.0.0)
+set (LIBSOUP_REQUIRED ^2.40)
 
 #gst-plugins dependencies
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.5>=${GST_REQUIRED})
@@ -41,6 +43,7 @@ pkg_check_modules(GSTREAMER_CHECK REQUIRED gstreamer-check-1.5>=${GST_REQUIRED})
 pkg_check_modules(KMSCORE REQUIRED kmscore)
 pkg_check_modules(KMSGSTCOMMONS REQUIRED kmsgstcommons)
 pkg_check_modules(OPENCV REQUIRED opencv>=${OPENCV_REQUIRED})
+generic_find (LIBNAME libsoup-2.4 VERSION ${LIBSOUP_REQUIRED} REQUIRED)
 
 set (VERSION ${PROJECT_VERSION})
 set (PACKAGE ${PROJECT_NAME})

--- a/modules/nubo_ear/nubo-ear-detector/debian/control
+++ b/modules/nubo_ear/nubo-ear-detector/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 8.0.0),
  kms-core-6.0-dev,
  kms-elements-6.0-dev,
  kms-filters-6.0-dev,
- libopencv-dev
+ libopencv-dev,
+ libsoup2.4-dev
 Standards-Version: 3.9.4
 
 Package: nubo-ear-detector

--- a/modules/nubo_ear/nubo-ear-detector/src/gst-plugins/CMakeLists.txt
+++ b/modules/nubo_ear/nubo-ear-detector/src/gst-plugins/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(
   ${GSTREAMER_INCLUDE_DIRS}
   ${GSTREAMER_VIDEO_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
+  ${libsoup-2.4_INCLUDE_DIRS}
   ${OPENCV_INCLUDE_DIRS}
 )
 
@@ -19,6 +20,7 @@ target_link_libraries(nuboeardetector
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_VIDEO_LIBRARIES}
   ${OPENCV_LIBRARIES}
+  ${libsoup-2.4_LIBRARIES}
 )
 
 install(

--- a/modules/nubo_ear/nubo-ear-detector/src/server/implementation/objects/NuboEarDetectorImpl.cpp
+++ b/modules/nubo_ear/nubo-ear-detector/src/server/implementation/objects/NuboEarDetectorImpl.cpp
@@ -192,6 +192,33 @@ namespace kurento
 	g_object_set (G_OBJECT (nubo_ear), EVENTS_MS , ms , NULL);
       }
 
+      void NuboEarDetectorImpl::unsetOverlayedImage ()
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, 0.0,
+                                     "offsetYPercent", G_TYPE_DOUBLE, 0.0,
+                                     "widthPercent", G_TYPE_DOUBLE, 0.0,
+                                     "heightPercent", G_TYPE_DOUBLE, 0.0,
+                                     "url", G_TYPE_STRING, NULL,
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_ear), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
+      void NuboEarDetectorImpl::setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent)
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, double (offsetXPercent),
+                                     "offsetYPercent", G_TYPE_DOUBLE, double (offsetYPercent),
+                                     "widthPercent", G_TYPE_DOUBLE, double (widthPercent),
+                                     "heightPercent", G_TYPE_DOUBLE, double (heightPercent),
+                                     "url", G_TYPE_STRING, uri.c_str(),
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_ear), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
 
       MediaObjectImpl *
       NuboEarDetectorImplFactory::createObject (const boost::property_tree::ptree &config,

--- a/modules/nubo_ear/nubo-ear-detector/src/server/implementation/objects/NuboEarDetectorImpl.hpp
+++ b/modules/nubo_ear/nubo-ear-detector/src/server/implementation/objects/NuboEarDetectorImpl.hpp
@@ -52,6 +52,8 @@ public:
   void processXevery4Frames(int xper4);
   void widthToProcess(int width);
   void activateServerEvents (int activate,int ms);
+  void unsetOverlayedImage ();
+  void setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent);
 
   sigc::signal<void, OnEar> signalOnEar;
   /* Next methods are automatically implemented by code generator */

--- a/modules/nubo_ear/nubo-ear-detector/src/server/interface/nuboeardetector.NuboEarDetector.kmd.json
+++ b/modules/nubo_ear/nubo-ear-detector/src/server/interface/nuboeardetector.NuboEarDetector.kmd.json
@@ -97,7 +97,43 @@
 			    "type": "int"
 			}
 		    ]
-		}
+        },
+        {
+          "name": "unsetOverlayedImage",
+          "doc": "Clear the image to be shown over each detected ear. Stops overlaying the ears.",
+          "params": []
+        },
+        {
+          "name": "setOverlayedImage",
+          "doc": "Sets the image to use as overlay on the detected ear.",
+          "params": [
+            {
+              "name": "uri",
+              "doc": "URI where the image is located",
+              "type": "String"
+            },
+            {
+              "name": "offsetXPercent",
+              "doc": "the offset applied to the image, from the X coordinate of the detected ear upper right corner. A positive value indicates right displacement, while a negative value moves the overlaid image to the left. This offset is specified as a percentage of the ear width.\n\nFor example, to cover the detected ear with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the ear´s X coord, +- the ear´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "offsetYPercent",
+              "doc": "the offset applied to the image, from the Y coordinate of the detected ear upper right corner. A positive value indicates up displacement, while a negative value moves the overlaid image down. This offset is specified as a percentage of the ear width.\n\nFor example, to cover the detected ear with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the ear´s Y coord, +- the ear´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "widthPercent",
+              "doc": "proportional width of the overlaid image, relative to the width of the detected ear. A value of 1.0 implies that the overlaid image will have the same width as the detected ear. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "heightPercent",
+              "doc": "proportional height of the overlaid image, relative to the height of the detected ear. A value of 1.0 implies that the overlaid image will have the same height as the detected ear. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            }
+          ]
+        }
 	    ],
 
 	    "events": [

--- a/modules/nubo_ear/nubo-ear-detector/src/server/interface/nuboeardetector.kmd.json
+++ b/modules/nubo_ear/nubo-ear-detector/src/server/interface/nuboeardetector.kmd.json
@@ -1,5 +1,5 @@
 {
   "name": "nuboeardetector",
-  "version": "6.4.02",
+  "version": "6.4.03-dev",
   "kurentoVersion": "^6.0.0"
 }

--- a/modules/nubo_eye/nubo-eye-detector/CMakeLists.txt
+++ b/modules/nubo_eye/nubo-eye-detector/CMakeLists.txt
@@ -29,10 +29,12 @@ if (${_len} GREATER 2)
 endif ()
 
 find_package(PkgConfig)
+include (GenericFind)
 
 set (GST_REQUIRED 1.3.3)
 set (GLIB_REQUIRED 2.38)
 set (OPENCV_REQUIRED 2.0.0)
+set (LIBSOUP_REQUIRED ^2.40)
 
 #gst-plugins dependencies
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.5>=${GST_REQUIRED})
@@ -42,6 +44,7 @@ pkg_check_modules(GSTREAMER_CHECK REQUIRED gstreamer-check-1.5>=${GST_REQUIRED})
 pkg_check_modules(KMSCORE REQUIRED kmscore)
 pkg_check_modules(KMSGSTCOMMONS REQUIRED kmsgstcommons)
 pkg_check_modules(OPENCV REQUIRED opencv>=${OPENCV_REQUIRED})
+generic_find (LIBNAME libsoup-2.4 VERSION ${LIBSOUP_REQUIRED} REQUIRED)
 
 set (VERSION ${PROJECT_VERSION})
 set (PACKAGE ${PROJECT_NAME})

--- a/modules/nubo_eye/nubo-eye-detector/debian/control
+++ b/modules/nubo_eye/nubo-eye-detector/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 8.0.0),
  kms-core-6.0-dev,
  kms-elements-6.0-dev,
  kms-filters-6.0-dev,
- libopencv-dev
+ libopencv-dev,
+ libsoup2.4-dev
 Standards-Version: 3.9.4
 
 Package: nubo-eye-detector

--- a/modules/nubo_eye/nubo-eye-detector/src/gst-plugins/CMakeLists.txt
+++ b/modules/nubo_eye/nubo-eye-detector/src/gst-plugins/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
   ${GSTREAMER_INCLUDE_DIRS}
   ${GSTREAMER_VIDEO_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
+  ${libsoup-2.4_INCLUDE_DIRS}
   ${OPENCV_INCLUDE_DIRS}
 )
 
@@ -21,6 +22,7 @@ target_link_libraries(nuboeyedetector
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_VIDEO_LIBRARIES}
   ${OPENCV_LIBRARIES}
+  ${libsoup-2.4_LIBRARIES}
 )
 
 install(

--- a/modules/nubo_eye/nubo-eye-detector/src/gst-plugins/kmseyedetect.cpp
+++ b/modules/nubo_eye/nubo-eye-detector/src/gst-plugins/kmseyedetect.cpp
@@ -740,7 +740,7 @@ kms_eye_detect_process_frame(KmsEyeDetect *eye_detect,int width,int height,doubl
 
       for( vector<Rect>::iterator r = faces->begin(); r != faces->end(); r++, i++ )
 	{   
-	  vector<Rect> *result_aux;
+    vector<Rect> *result_aux = NULL;
 	  /*To detect eyes we need to work in the normal width 640 480*/
 	  r_aux.x = r->x*scale_f2e;
 	  r_aux.y = r->y*scale_f2e;
@@ -792,7 +792,9 @@ kms_eye_detect_process_frame(KmsEyeDetect *eye_detect,int width,int height,doubl
 
 	  if (eye_l.size() > 0)
 	    {
-	      if (result_aux->size()>0) result_aux->clear();
+        if (result_aux != NULL) {
+          if (result_aux->size()>0) result_aux->clear();
+        }
 	      
 	      __merge_eyes_current_frame(f_aux_l,res_r,eye_l,scale_o2e,true);	      
 	      result_aux= __merge_eyes_consecutives_frames(&eye_l,eyes_l,f_aux_l,scale_o2e,true);  

--- a/modules/nubo_eye/nubo-eye-detector/src/server/implementation/objects/NuboEyeDetectorImpl.cpp
+++ b/modules/nubo_eye/nubo-eye-detector/src/server/implementation/objects/NuboEyeDetectorImpl.cpp
@@ -190,6 +190,34 @@ namespace kurento
 	g_object_set (G_OBJECT (nubo_eye), EVENTS_MS , ms , NULL);
       }      
 
+      void NuboEyeDetectorImpl::unsetOverlayedImage ()
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, 0.0,
+                                     "offsetYPercent", G_TYPE_DOUBLE, 0.0,
+                                     "widthPercent", G_TYPE_DOUBLE, 0.0,
+                                     "heightPercent", G_TYPE_DOUBLE, 0.0,
+                                     "url", G_TYPE_STRING, NULL,
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_eye), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
+      void NuboEyeDetectorImpl::setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent)
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, double (offsetXPercent),
+                                     "offsetYPercent", G_TYPE_DOUBLE, double (offsetYPercent),
+                                     "widthPercent", G_TYPE_DOUBLE, double (widthPercent),
+                                     "heightPercent", G_TYPE_DOUBLE, double (heightPercent),
+                                     "url", G_TYPE_STRING, uri.c_str(),
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_eye), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
       MediaObjectImpl *
       NuboEyeDetectorImplFactory::createObject (const boost::property_tree::ptree &config, std::shared_ptr<MediaPipeline> mediaPipeline) const
       {

--- a/modules/nubo_eye/nubo-eye-detector/src/server/implementation/objects/NuboEyeDetectorImpl.hpp
+++ b/modules/nubo_eye/nubo-eye-detector/src/server/implementation/objects/NuboEyeDetectorImpl.hpp
@@ -53,6 +53,8 @@ namespace kurento
 	void processXevery4Frames(int xper4);
 	void widthToProcess(int width);
 	void activateServerEvents (int activate,int ms);
+  void unsetOverlayedImage ();
+  void setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent);
 
 	sigc::signal<void, OnEye> signalOnEye;
 	/* Next methods are automatically implemented by code generator */

--- a/modules/nubo_eye/nubo-eye-detector/src/server/interface/nuboeyedetector.NuboEyeDetector.kmd.json
+++ b/modules/nubo_eye/nubo-eye-detector/src/server/interface/nuboeyedetector.NuboEyeDetector.kmd.json
@@ -97,8 +97,43 @@
 			    "type": "int"
 			}
 		    ]
-		}
-		
+        },
+        {
+          "name": "unsetOverlayedImage",
+          "doc": "Clear the image to be shown over each detected face. Stops overlaying the faces.",
+          "params": []
+        },
+        {
+          "name": "setOverlayedImage",
+          "doc": "Sets the image to use as overlay on the detected faces.",
+          "params": [
+            {
+              "name": "uri",
+              "doc": "URI where the image is located",
+              "type": "String"
+            },
+            {
+              "name": "offsetXPercent",
+              "doc": "the offset applied to the image, from the X coordinate of the detected face upper right corner. A positive value indicates right displacement, while a negative value moves the overlaid image to the left. This offset is specified as a percentage of the face width.\n\nFor example, to cover the detected face with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the face´s X coord, +- the face´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "offsetYPercent",
+              "doc": "the offset applied to the image, from the Y coordinate of the detected face upper right corner. A positive value indicates up displacement, while a negative value moves the overlaid image down. This offset is specified as a percentage of the face width.\n\nFor example, to cover the detected face with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the face´s Y coord, +- the face´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "widthPercent",
+              "doc": "proportional width of the overlaid image, relative to the width of the detected face. A value of 1.0 implies that the overlaid image will have the same width as the detected face. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "heightPercent",
+              "doc": "proportional height of the overlaid image, relative to the height of the detected face. A value of 1.0 implies that the overlaid image will have the same height as the detected face. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            }
+          ]
+        }
 	    ],
 	    
 	    "events": [

--- a/modules/nubo_eye/nubo-eye-detector/src/server/interface/nuboeyedetector.kmd.json
+++ b/modules/nubo_eye/nubo-eye-detector/src/server/interface/nuboeyedetector.kmd.json
@@ -1,5 +1,5 @@
 {
   "name": "nuboeyedetector",
-  "version": "6.4.02",
+  "version": "6.4.03-dev",
   "kurentoVersion": "^6.0.0"
 }

--- a/modules/nubo_face/nubo-face-detector/CMakeLists.txt
+++ b/modules/nubo_face/nubo-face-detector/CMakeLists.txt
@@ -28,11 +28,13 @@ if (${_len} GREATER 2)
 endif ()
 
 find_package(PkgConfig)
+include (GenericFind)
 
 set (GST_REQUIRED ~1.5.0)
 set (GLIB_REQUIRED 2.38)
 set (OPENCV_REQUIRED 2.0.0)
 set (GLIBMM_REQUIRED ^2.37)
+set (LIBSOUP_REQUIRED ^2.40)
 
 #gst-plugins dependencies
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.5>=${GST_REQUIRED})
@@ -42,9 +44,7 @@ pkg_check_modules(GSTREAMER_CHECK REQUIRED gstreamer-check-1.5>=${GST_REQUIRED})
 pkg_check_modules(KMSCORE REQUIRED kmscore)
 pkg_check_modules(KMSGSTCOMMONS REQUIRED kmsgstcommons)
 pkg_check_modules(OPENCV REQUIRED opencv>=${OPENCV_REQUIRED})
-
-
-
+generic_find (LIBNAME libsoup-2.4 VERSION ${LIBSOUP_REQUIRED} REQUIRED)
 
 set (VERSION ${PROJECT_VERSION})
 set (PACKAGE ${PROJECT_NAME})

--- a/modules/nubo_face/nubo-face-detector/debian/control
+++ b/modules/nubo_face/nubo-face-detector/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 8.0.0),
  kms-core-6.0-dev,
  kms-elements-6.0-dev,
  kms-filters-6.0-dev,
- libopencv-dev
+ libopencv-dev,
+ libsoup2.4-dev
 Standards-Version: 3.9.4
 
 Package: nubo-face-detector

--- a/modules/nubo_face/nubo-face-detector/src/gst-plugins/CMakeLists.txt
+++ b/modules/nubo_face/nubo-face-detector/src/gst-plugins/CMakeLists.txt
@@ -6,8 +6,8 @@ include_directories(
   ${GSTREAMER_VIDEO_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${OPENCV_INCLUDE_DIRS}
+  ${libsoup-2.4_INCLUDE_DIRS}
   ${CMAKE_CURRENT_BINARY_DIR}
-
 )
 
 
@@ -30,6 +30,7 @@ target_link_libraries(nubofacedetector
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_VIDEO_LIBRARIES}
   ${OPENCV_LIBRARIES}
+  ${libsoup-2.4_LIBRARIES}
 )
 
 install(

--- a/modules/nubo_face/nubo-face-detector/src/server/implementation/objects/NuboFaceDetectorImpl.cpp
+++ b/modules/nubo_face/nubo-face-detector/src/server/implementation/objects/NuboFaceDetectorImpl.cpp
@@ -208,6 +208,34 @@ void NuboFaceDetectorImpl::areaThreshold (int threshold)
   g_object_set (G_OBJECT (nubo_face), EVENTS_MS , ms , NULL);
 }
 
+void NuboFaceDetectorImpl::unsetOverlayedImage ()
+{
+  GstStructure *imageSt;
+  imageSt = gst_structure_new ("image",
+                               "offsetXPercent", G_TYPE_DOUBLE, 0.0,
+                               "offsetYPercent", G_TYPE_DOUBLE, 0.0,
+                               "widthPercent", G_TYPE_DOUBLE, 0.0,
+                               "heightPercent", G_TYPE_DOUBLE, 0.0,
+                               "url", G_TYPE_STRING, NULL,
+                               NULL);
+  g_object_set (G_OBJECT (nubo_face), "image-to-overlay", imageSt, NULL);
+  gst_structure_free (imageSt);
+}
+
+void NuboFaceDetectorImpl::setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent)
+{
+  GstStructure *imageSt;
+  imageSt = gst_structure_new ("image",
+                               "offsetXPercent", G_TYPE_DOUBLE, double (offsetXPercent),
+                               "offsetYPercent", G_TYPE_DOUBLE, double (offsetYPercent),
+                               "widthPercent", G_TYPE_DOUBLE, double (widthPercent),
+                               "heightPercent", G_TYPE_DOUBLE, double (heightPercent),
+                               "url", G_TYPE_STRING, uri.c_str(),
+                               NULL);
+  g_object_set (G_OBJECT (nubo_face), "image-to-overlay", imageSt, NULL);
+  gst_structure_free (imageSt);
+}
+
 MediaObjectImpl *
 NuboFaceDetectorImplFactory::createObject (const boost::property_tree::ptree &config, std::shared_ptr<MediaPipeline> mediaPipeline) const
 {

--- a/modules/nubo_face/nubo-face-detector/src/server/implementation/objects/NuboFaceDetectorImpl.hpp
+++ b/modules/nubo_face/nubo-face-detector/src/server/implementation/objects/NuboFaceDetectorImpl.hpp
@@ -55,6 +55,8 @@ public:
   void trackThreshold (int threshold);
   void areaThreshold (int threshold);
   void activateServerEvents (int activate,int ms);
+  void unsetOverlayedImage ();
+  void setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent);
 
   /* Next methods are automatically implemented by code generator */
   virtual bool connect (const std::string &eventType, std::shared_ptr<EventHandler> handler);

--- a/modules/nubo_face/nubo-face-detector/src/server/interface/nubofacedetector.NuboFaceDetector.kmd.json
+++ b/modules/nubo_face/nubo-face-detector/src/server/interface/nubofacedetector.NuboFaceDetector.kmd.json
@@ -139,9 +139,45 @@
 			    "type": "int"
 			}
 		    ]
-		}
-		
-	    ],
+        },
+        {
+          "name": "unsetOverlayedImage",
+          "doc": "Clear the image to be shown over each detected face. Stops overlaying the faces.",
+          "params": []
+        },
+        {
+          "name": "setOverlayedImage",
+          "doc": "Sets the image to use as overlay on the detected faces.",
+          "params": [
+            {
+              "name": "uri",
+              "doc": "URI where the image is located",
+              "type": "String"
+            },
+            {
+              "name": "offsetXPercent",
+              "doc": "the offset applied to the image, from the X coordinate of the detected face upper right corner. A positive value indicates right displacement, while a negative value moves the overlaid image to the left. This offset is specified as a percentage of the face width.\n\nFor example, to cover the detected face with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the face´s X coord, +- the face´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "offsetYPercent",
+              "doc": "the offset applied to the image, from the Y coordinate of the detected face upper right corner. A positive value indicates up displacement, while a negative value moves the overlaid image down. This offset is specified as a percentage of the face width.\n\nFor example, to cover the detected face with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the face´s Y coord, +- the face´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "widthPercent",
+              "doc": "proportional width of the overlaid image, relative to the width of the detected face. A value of 1.0 implies that the overlaid image will have the same width as the detected face. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "heightPercent",
+              "doc": "proportional height of the overlaid image, relative to the height of the detected face. A value of 1.0 implies that the overlaid image will have the same height as the detected face. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            }
+          ]
+        }
+
+        ],
 	    "events": [
 		"OnFace"
 	    ]

--- a/modules/nubo_face/nubo-face-detector/src/server/interface/nubofacedetector.kmd.json
+++ b/modules/nubo_face/nubo-face-detector/src/server/interface/nubofacedetector.kmd.json
@@ -1,5 +1,5 @@
 {
     "name": "nubofacedetector",
-    "version": "6.4.02",
+    "version": "6.4.03-dev",
     "kurentoVersion": "^6.0.0"
 }

--- a/modules/nubo_mouth/nubo-mouth-detector/CMakeLists.txt
+++ b/modules/nubo_mouth/nubo-mouth-detector/CMakeLists.txt
@@ -28,10 +28,12 @@ if (${_len} GREATER 2)
 endif ()
 
 find_package(PkgConfig)
+include (GenericFind)
 
 set (GST_REQUIRED 1.3.3)
 set (GLIB_REQUIRED 2.38)
 set (OPENCV_REQUIRED 2.0.0)
+set (LIBSOUP_REQUIRED ^2.40)
 
 #gst-plugins dependencies
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.5>=${GST_REQUIRED})
@@ -41,6 +43,7 @@ pkg_check_modules(GSTREAMER_CHECK REQUIRED gstreamer-check-1.5>=${GST_REQUIRED})
 pkg_check_modules(KMSCORE REQUIRED kmscore)
 pkg_check_modules(KMSGSTCOMMONS REQUIRED kmsgstcommons)
 pkg_check_modules(OPENCV REQUIRED opencv>=${OPENCV_REQUIRED})
+generic_find (LIBNAME libsoup-2.4 VERSION ${LIBSOUP_REQUIRED} REQUIRED)
 
 set (VERSION ${PROJECT_VERSION})
 set (PACKAGE ${PROJECT_NAME})

--- a/modules/nubo_mouth/nubo-mouth-detector/debian/control
+++ b/modules/nubo_mouth/nubo-mouth-detector/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 8.0.0),
  kms-core-6.0-dev,
  kms-elements-6.0-dev,
  kms-filters-6.0-dev,
- libopencv-dev
+ libopencv-dev,
+ libsoup2.4-dev
 Standards-Version: 3.9.4
 
 Package: nubo-mouth-detector

--- a/modules/nubo_mouth/nubo-mouth-detector/src/gst-plugins/CMakeLists.txt
+++ b/modules/nubo_mouth/nubo-mouth-detector/src/gst-plugins/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(
   ${GSTREAMER_INCLUDE_DIRS}
   ${GSTREAMER_VIDEO_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
+  ${libsoup-2.4_INCLUDE_DIRS}
   ${OPENCV_INCLUDE_DIRS}
 )
 
@@ -19,6 +20,7 @@ target_link_libraries(nubomouthdetector
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_VIDEO_LIBRARIES}
   ${OPENCV_LIBRARIES}
+  ${libsoup-2.4_LIBRARIES}
 )
 
 install(

--- a/modules/nubo_mouth/nubo-mouth-detector/src/server/implementation/objects/NuboMouthDetectorImpl.cpp
+++ b/modules/nubo_mouth/nubo-mouth-detector/src/server/implementation/objects/NuboMouthDetectorImpl.cpp
@@ -192,6 +192,34 @@ namespace kurento
 	g_object_set (G_OBJECT (nubo_mouth), EVENTS_MS , ms , NULL);
       }
 
+      void NuboMouthDetectorImpl::unsetOverlayedImage ()
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, 0.0,
+                                     "offsetYPercent", G_TYPE_DOUBLE, 0.0,
+                                     "widthPercent", G_TYPE_DOUBLE, 0.0,
+                                     "heightPercent", G_TYPE_DOUBLE, 0.0,
+                                     "url", G_TYPE_STRING, NULL,
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_mouth), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
+      void NuboMouthDetectorImpl::setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent)
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, double (offsetXPercent),
+                                     "offsetYPercent", G_TYPE_DOUBLE, double (offsetYPercent),
+                                     "widthPercent", G_TYPE_DOUBLE, double (widthPercent),
+                                     "heightPercent", G_TYPE_DOUBLE, double (heightPercent),
+                                     "url", G_TYPE_STRING, uri.c_str(),
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_mouth), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
       MediaObjectImpl *
       NuboMouthDetectorImplFactory::createObject (const boost::property_tree::ptree &config, std::shared_ptr<MediaPipeline> mediaPipeline) const
       {

--- a/modules/nubo_mouth/nubo-mouth-detector/src/server/implementation/objects/NuboMouthDetectorImpl.hpp
+++ b/modules/nubo_mouth/nubo-mouth-detector/src/server/implementation/objects/NuboMouthDetectorImpl.hpp
@@ -52,6 +52,8 @@ public:
   void processXevery4Frames(int xper4);
   void widthToProcess(int width);
   void activateServerEvents (int activate,int ms);
+  void unsetOverlayedImage ();
+  void setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent);
 
   /* Next methods are automatically implemented by code generator */
   sigc::signal<void, OnMouth> signalOnMouth;

--- a/modules/nubo_mouth/nubo-mouth-detector/src/server/interface/nubomouthdetector.NuboMouthDetector.kmd.json
+++ b/modules/nubo_mouth/nubo-mouth-detector/src/server/interface/nubomouthdetector.NuboMouthDetector.kmd.json
@@ -97,7 +97,43 @@
 			    "type": "int"
 			}
 		    ]
-		}
+        },
+        {
+          "name": "unsetOverlayedImage",
+          "doc": "Clear the image to be shown over each detected mouth. Stops overlaying the mouths.",
+          "params": []
+        },
+        {
+          "name": "setOverlayedImage",
+          "doc": "Sets the image to use as overlay on the detected mouths.",
+          "params": [
+            {
+              "name": "uri",
+              "doc": "URI where the image is located",
+              "type": "String"
+            },
+            {
+              "name": "offsetXPercent",
+              "doc": "the offset applied to the image, from the X coordinate of the detected mouth upper right corner. A positive value indicates right displacement, while a negative value moves the overlaid image to the left. This offset is specified as a percentage of the mouth width.\n\nFor example, to cover the detected mouth with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the mouth´s X coord, +- the mouth´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "offsetYPercent",
+              "doc": "the offset applied to the image, from the Y coordinate of the detected mouth upper right corner. A positive value indicates up displacement, while a negative value moves the overlaid image down. This offset is specified as a percentage of the mouth width.\n\nFor example, to cover the detected mouth with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the mouth´s Y coord, +- the mouth´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "widthPercent",
+              "doc": "proportional width of the overlaid image, relative to the width of the detected mouth. A value of 1.0 implies that the overlaid image will have the same width as the detected mouth. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "heightPercent",
+              "doc": "proportional height of the overlaid image, relative to the height of the detected mouth. A value of 1.0 implies that the overlaid image will have the same height as the detected mouth. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            }
+          ]
+        }
 
 	    ],	    
 	    "events": [

--- a/modules/nubo_mouth/nubo-mouth-detector/src/server/interface/nubomouthdetector.kmd.json
+++ b/modules/nubo_mouth/nubo-mouth-detector/src/server/interface/nubomouthdetector.kmd.json
@@ -1,5 +1,5 @@
 {
   "name": "nubomouthdetector",
-  "version": "6.4.02",
+  "version": "6.4.03-dev",
   "kurentoVersion": "^6.0.0"
 }

--- a/modules/nubo_nose/nubo-nose-detector/CMakeLists.txt
+++ b/modules/nubo_nose/nubo-nose-detector/CMakeLists.txt
@@ -29,10 +29,12 @@ if (${_len} GREATER 2)
 endif ()
 
 find_package(PkgConfig)
+include (GenericFind)
 
 set (GST_REQUIRED ~1.5.0)
 set (GLIB_REQUIRED 2.38)
 set (OPENCV_REQUIRED 2.0.0)
+set (LIBSOUP_REQUIRED ^2.40)
 
 #gst-plugins dependencies
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.5>=${GST_REQUIRED})
@@ -42,6 +44,7 @@ pkg_check_modules(GSTREAMER_CHECK REQUIRED gstreamer-check-1.5>=${GST_REQUIRED})
 pkg_check_modules(KMSCORE REQUIRED kmscore)
 pkg_check_modules(KMSGSTCOMMONS REQUIRED kmsgstcommons)
 pkg_check_modules(OPENCV REQUIRED opencv>=${OPENCV_REQUIRED})
+generic_find (LIBNAME libsoup-2.4 VERSION ${LIBSOUP_REQUIRED} REQUIRED)
 
 set (VERSION ${PROJECT_VERSION})
 set (PACKAGE ${PROJECT_NAME})

--- a/modules/nubo_nose/nubo-nose-detector/debian/control
+++ b/modules/nubo_nose/nubo-nose-detector/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 8.0.0),
  kms-core-6.0-dev,
  kms-elements-6.0-dev,
  kms-filters-6.0-dev,
- libopencv-dev
+ libopencv-dev,
+ libsoup2.4-dev
 Standards-Version: 3.9.4
 
 Package: nubo-nose-detector

--- a/modules/nubo_nose/nubo-nose-detector/src/gst-plugins/CMakeLists.txt
+++ b/modules/nubo_nose/nubo-nose-detector/src/gst-plugins/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
   ${GSTREAMER_VIDEO_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${OPENCV_INCLUDE_DIRS}
+  ${libsoup-2.4_INCLUDE_DIRS}
 )
 
 set(NUBO_NOSE_DETECTOR_SOURCES
@@ -21,6 +22,7 @@ target_link_libraries(nubonosedetector
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_VIDEO_LIBRARIES}
   ${OPENCV_LIBRARIES}
+  ${libsoup-2.4_LIBRARIES}
 )
 
 install(

--- a/modules/nubo_nose/nubo-nose-detector/src/gst-plugins/kmsnosedetect.cpp
+++ b/modules/nubo_nose/nubo-nose-detector/src/gst-plugins/kmsnosedetect.cpp
@@ -18,7 +18,8 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
-
+#include <libsoup/soup.h>
+#include <ftw.h>
 
 #define PLUGIN_NAME "nubonosedetector"
 #define FACE_WIDTH 160
@@ -42,6 +43,9 @@
 #define DEFAULT_EUCLIDEAN_DIS 6
 #define SERVER_EVENTS 0
 #define EVENTS_MS 30001
+
+#define TEMP_PATH "/tmp/XXXXXX"
+#define SRC_OVERLAY ((double)1)
 
 using namespace cv;
 
@@ -72,7 +76,8 @@ enum {
   PROP_PROCESS_X_EVERY_4_FRAMES,
   PROP_ACTIVATE_SERVER_EVENTS,
   PROP_SERVER_EVENTS_MS,
-  PROP_SHOW_DEBUG_INFO
+  PROP_SHOW_DEBUG_INFO,
+  PROP_IMAGE_TO_OVERLAY
 };
 
 
@@ -117,6 +122,11 @@ struct _KmsNoseDetectPrivate {
   //1 => it will send the bounding box of the nose as metadata 
   /*num_frames_to_process*/
   // When we receive an event we need to process at least NUM_FRAMES_TO_PROCESS
+  GstStructure *image_to_overlay;
+  gdouble offsetXPercent, offsetYPercent, widthPercent, heightPercent;
+  IplImage *costume;
+  gboolean dir_created;
+  gchar *dir;
 };
 
 /* pad templates */
@@ -297,6 +307,202 @@ kms_nose_detect_conf_images (KmsNoseDetect *nose_detect,
   nose_detect->priv->img_orig->imageData = (char *) info.data;
 }
 
+static gboolean
+is_valid_uri (const gchar * url)
+{
+  gboolean ret;
+  GRegex *regex;
+
+  regex = g_regex_new ("^(?:((?:https?):)\\/\\/)([^:\\/\\s]+)(?::(\\d*))?(?:\\/"
+      "([^\\s?#]+)?([?][^?#]*)?(#.*)?)?$", (GRegexCompileFlags) 0, (GRegexMatchFlags) 0, NULL);
+  ret = g_regex_match (regex, url, G_REGEX_MATCH_ANCHORED, NULL);
+  g_regex_unref (regex);
+
+  return ret;
+}
+
+static void
+load_from_url (gchar * file_name, gchar * url)
+{
+  SoupSession *session;
+  SoupMessage *msg;
+  FILE *dst;
+
+  session = soup_session_sync_new ();
+  msg = soup_message_new ("GET", url);
+  soup_session_send_message (session, msg);
+
+  dst = fopen (file_name, "w+");
+
+  if (dst == NULL) {
+    GST_ERROR ("It is not possible to create the file");
+    goto end;
+  }
+  fwrite (msg->response_body->data, 1, msg->response_body->length, dst);
+  fclose (dst);
+
+end:
+  g_object_unref (msg);
+  g_object_unref (session);
+}
+
+static void
+kms_nose_detect_load_image_to_overlay (KmsNoseDetect * nosedetect)
+{
+  gchar *url = NULL;
+  IplImage *costumeAux = NULL;
+  gboolean fields_ok = TRUE;
+
+  fields_ok = fields_ok
+      && gst_structure_get (nosedetect->priv->image_to_overlay,
+      "offsetXPercent", G_TYPE_DOUBLE, &nosedetect->priv->offsetXPercent,
+      NULL);
+  fields_ok = fields_ok
+      && gst_structure_get (nosedetect->priv->image_to_overlay,
+      "offsetYPercent", G_TYPE_DOUBLE, &nosedetect->priv->offsetYPercent,
+      NULL);
+  fields_ok = fields_ok
+      && gst_structure_get (nosedetect->priv->image_to_overlay,
+      "widthPercent", G_TYPE_DOUBLE, &nosedetect->priv->widthPercent, NULL);
+  fields_ok = fields_ok
+      && gst_structure_get (nosedetect->priv->image_to_overlay,
+      "heightPercent", G_TYPE_DOUBLE, &nosedetect->priv->heightPercent, NULL);
+  fields_ok = fields_ok
+      && gst_structure_get (nosedetect->priv->image_to_overlay, "url",
+      G_TYPE_STRING, &url, NULL);
+
+  if (!fields_ok) {
+    GST_WARNING_OBJECT (nosedetect, "Invalid image structure received");
+    goto end;
+  }
+
+  if (url == NULL) {
+    GST_DEBUG ("Unset the image overlay");
+    goto end;
+  }
+
+  if (!nosedetect->priv->dir_created) {
+    gchar *d = g_strdup (TEMP_PATH);
+
+    nosedetect->priv->dir = g_mkdtemp (d);
+    nosedetect->priv->dir_created = TRUE;
+  }
+
+  costumeAux = cvLoadImage (url, CV_LOAD_IMAGE_UNCHANGED);
+
+  if (costumeAux != NULL) {
+    GST_DEBUG ("Image loaded from file");
+    goto end;
+  }
+
+  if (is_valid_uri (url)) {
+    gchar *file_name =
+        g_strconcat (nosedetect->priv->dir, "/image.png", NULL);
+    load_from_url (file_name, url);
+    costumeAux = cvLoadImage (file_name, CV_LOAD_IMAGE_UNCHANGED);
+    g_remove (file_name);
+    g_free (file_name);
+  }
+
+  if (costumeAux == NULL) {
+    GST_ERROR_OBJECT (nosedetect, "Overlay image not loaded");
+  } else {
+    GST_DEBUG_OBJECT (nosedetect, "Image loaded from URL");
+  }
+
+end:
+
+  if (nosedetect->priv->costume != NULL) {
+    cvReleaseImage (&nosedetect->priv->costume);
+    nosedetect->priv->costume = NULL;
+    nosedetect->priv->view_noses = 0;
+  }
+
+  if (costumeAux != NULL) {
+    nosedetect->priv->costume = costumeAux;
+    nosedetect->priv->view_noses = 1;
+  }
+
+  g_free (url);
+}
+
+static void
+kms_nose_detect_display_detections_overlay_img (KmsNoseDetect * nosedetect,
+                                                int x, int y,
+                                                int width, int height)
+{
+  IplImage *costumeAux;
+  int w, h;
+  uchar *row, *image_row;
+
+  if ((nosedetect->priv->heightPercent == 0) ||
+      (nosedetect->priv->widthPercent == 0)) {
+    return;
+  }
+
+  x = x + (width * (nosedetect->priv->offsetXPercent));
+  y = y + (height * (nosedetect->priv->offsetYPercent));
+  height = height * (nosedetect->priv->heightPercent);
+  width = width * (nosedetect->priv->widthPercent);
+
+  costumeAux = cvCreateImage (cvSize (width, height),
+      nosedetect->priv->costume->depth,
+      nosedetect->priv->costume->nChannels);
+  cvResize (nosedetect->priv->costume, costumeAux, CV_INTER_LINEAR);
+
+  row = (uchar *) costumeAux->imageData;
+  image_row = (uchar *) nosedetect->priv->img_orig->imageData +
+      (y * nosedetect->priv->img_orig->widthStep);
+
+  for (h = 0; h < costumeAux->height; h++) {
+
+    uchar *column = row;
+    uchar *image_column = image_row + (x * 3);
+
+    for (w = 0; w < costumeAux->width; w++) {
+      /* Check if point is inside overlay boundaries */
+      if (((w + x) < nosedetect->priv->img_orig->width)
+          && ((w + x) >= 0)) {
+        if (((h + y) < nosedetect->priv->img_orig->height)
+            && ((h + y) >= 0)) {
+
+          if (nosedetect->priv->costume->nChannels == 1) {
+            *(image_column) = (uchar) (*(column));
+            *(image_column + 1) = (uchar) (*(column));
+            *(image_column + 2) = (uchar) (*(column));
+          } else if (nosedetect->priv->costume->nChannels == 3) {
+            *(image_column) = (uchar) (*(column));
+            *(image_column + 1) = (uchar) (*(column + 1));
+            *(image_column + 2) = (uchar) (*(column + 2));
+          } else if (nosedetect->priv->costume->nChannels == 4) {
+            double proportion =
+                ((double) *(uchar *) (column + 3)) / (double) 255;
+            double overlay = SRC_OVERLAY * proportion;
+            double original = 1 - overlay;
+
+            *image_column =
+                (uchar) ((*column * overlay) + (*image_column * original));
+            *(image_column + 1) =
+                (uchar) ((*(column + 1) * overlay) + (*(image_column +
+                        1) * original));
+            *(image_column + 2) =
+                (uchar) ((*(column + 2) * overlay) + (*(image_column +
+                        2) * original));
+          }
+        }
+      }
+
+      column += nosedetect->priv->costume->nChannels;
+      image_column += nosedetect->priv->img_orig->nChannels;
+    }
+
+    row += costumeAux->widthStep;
+    image_row += nosedetect->priv->img_orig->widthStep;
+  }
+
+  cvReleaseImage (&costumeAux);
+}
+
 static void
 kms_nose_detect_set_property (GObject *object, guint property_id,
 			      const GValue *value, GParamSpec *pspec)
@@ -342,6 +548,14 @@ kms_nose_detect_set_property (GObject *object, guint property_id,
     
   case PROP_SERVER_EVENTS_MS:
     nose_detect->priv->events_ms = g_value_get_int(value);   
+    break;
+
+  case PROP_IMAGE_TO_OVERLAY:
+    if (nose_detect->priv->image_to_overlay != NULL)
+      gst_structure_free (nose_detect->priv->image_to_overlay);
+
+    nose_detect->priv->image_to_overlay = (GstStructure*) g_value_dup_boxed (value);
+    kms_nose_detect_load_image_to_overlay (nose_detect);
     break;
 
   default:
@@ -396,6 +610,14 @@ kms_nose_detect_get_property (GObject *object, guint property_id,
     
   case PROP_SERVER_EVENTS_MS:
     g_value_set_int(value,nose_detect->priv->events_ms);
+    break;
+
+  case PROP_IMAGE_TO_OVERLAY:
+    if (nose_detect->priv->image_to_overlay == NULL) {
+      nose_detect->priv->image_to_overlay =
+          gst_structure_new_empty ("image_to_overlay");
+    }
+    g_value_set_boxed (value, nose_detect->priv->image_to_overlay);
     break;
 
   default:
@@ -675,11 +897,15 @@ kms_nose_detect_process_frame(KmsNoseDetect *nose_detect,int width,int height,do
   if (1 == nose_detect->priv->view_noses  )
     for ( vector<Rect>::iterator m = noses->begin(); m != noses->end();m++,j++)	  
       {
-	color = colors[j%8];     
-	cvRectangle( nose_detect->priv->img_orig, cvPoint(m->x,m->y),
-		     cvPoint(cvRound(m->x + m->width), 
-			     cvRound(m->y+ m->height-1)),
-		     color, 3, 8, 0);	    
+        if (nose_detect->priv->costume == NULL) {
+          color = colors[j%8];
+          cvRectangle( nose_detect->priv->img_orig, cvPoint(m->x,m->y),
+                 cvPoint(cvRound(m->x + m->width),
+                   cvRound(m->y+ m->height-1)),
+                 color, 3, 8, 0);
+        } else {
+          kms_nose_detect_display_detections_overlay_img (nose_detect, m->x, m->y, m->width, m->height);
+        }
       }
   
 }
@@ -743,6 +969,25 @@ kms_nose_detect_dispose (GObject *object)
 {
 }
 
+static int
+delete_file (const char *fpath, const struct stat *sb, int typeflag,
+    struct FTW *ftwbuf)
+{
+  int rv = g_remove (fpath);
+
+  if (rv) {
+    GST_WARNING ("Error deleting file: %s. %s", fpath, strerror (errno));
+  }
+
+  return rv;
+}
+
+static void
+remove_recursive (const gchar * path)
+{
+  nftw (path, delete_file, 64, FTW_DEPTH | FTW_PHYS);
+}
+
 /*
  * The finalize function is called when the object is destroyed.
  */
@@ -752,6 +997,18 @@ kms_nose_detect_finalize (GObject *object)
   KmsNoseDetect *nose_detect = KMS_NOSE_DETECT(object);
 
   cvReleaseImage (&nose_detect->priv->img_orig);
+
+  if (nose_detect->priv->costume != NULL)
+    cvReleaseImage (&nose_detect->priv->costume);
+
+  if (nose_detect->priv->image_to_overlay != NULL)
+    gst_structure_free (nose_detect->priv->image_to_overlay);
+
+  if (nose_detect->priv->dir_created) {
+    remove_recursive (nose_detect->priv->dir);
+    g_free (nose_detect->priv->dir);
+  }
+
   delete nose_detect->priv->faces;
   delete nose_detect->priv->noses;
   g_rec_mutex_clear(&nose_detect->priv->mutex);
@@ -871,6 +1128,11 @@ g_object_class_install_property (gobject_class, PROP_WIDTH_TO_PROCCESS,
 				  g_param_spec_int ("events-ms",  "Activate Events",
 						    "the time, it takes to send events to the servers", 
 			          0,30000,FALSE, (GParamFlags) G_PARAM_READWRITE));
+
+ g_object_class_install_property (gobject_class, PROP_IMAGE_TO_OVERLAY,
+     g_param_spec_boxed ("image-to-overlay", "image to overlay",
+         "set the url of the image to overlay the noses",
+         GST_TYPE_STRUCTURE, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
   video_filter_class->transform_frame_ip =
     GST_DEBUG_FUNCPTR (kms_nose_detect_transform_frame_ip);

--- a/modules/nubo_nose/nubo-nose-detector/src/server/implementation/objects/NuboNoseDetectorImpl.cpp
+++ b/modules/nubo_nose/nubo-nose-detector/src/server/implementation/objects/NuboNoseDetectorImpl.cpp
@@ -187,6 +187,34 @@ void NuboNoseDetectorImpl::postConstructor ()
         g_object_set (G_OBJECT (nubo_nose), EVENTS_MS , ms , NULL);
       }
 
+      void NuboNoseDetectorImpl::unsetOverlayedImage ()
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, 0.0,
+                                     "offsetYPercent", G_TYPE_DOUBLE, 0.0,
+                                     "widthPercent", G_TYPE_DOUBLE, 0.0,
+                                     "heightPercent", G_TYPE_DOUBLE, 0.0,
+                                     "url", G_TYPE_STRING, NULL,
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_nose), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
+      void NuboNoseDetectorImpl::setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent)
+      {
+        GstStructure *imageSt;
+        imageSt = gst_structure_new ("image",
+                                     "offsetXPercent", G_TYPE_DOUBLE, double (offsetXPercent),
+                                     "offsetYPercent", G_TYPE_DOUBLE, double (offsetYPercent),
+                                     "widthPercent", G_TYPE_DOUBLE, double (widthPercent),
+                                     "heightPercent", G_TYPE_DOUBLE, double (heightPercent),
+                                     "url", G_TYPE_STRING, uri.c_str(),
+                                     NULL);
+        g_object_set (G_OBJECT (nubo_nose), "image-to-overlay", imageSt, NULL);
+        gst_structure_free (imageSt);
+      }
+
       MediaObjectImpl *
       NuboNoseDetectorImplFactory::createObject (const boost::property_tree::ptree &config, std::shared_ptr<MediaPipeline> mediaPipeline) const
       {

--- a/modules/nubo_nose/nubo-nose-detector/src/server/implementation/objects/NuboNoseDetectorImpl.hpp
+++ b/modules/nubo_nose/nubo-nose-detector/src/server/implementation/objects/NuboNoseDetectorImpl.hpp
@@ -53,6 +53,8 @@ namespace kurento
 	void processXevery4Frames(int xper4);
 	void widthToProcess(int width);
 	void activateServerEvents (int activate,int ms);
+        void unsetOverlayedImage ();
+        void setOverlayedImage (const std::string &uri, float offsetXPercent, float offsetYPercent, float widthPercent, float heightPercent);
 
 	/* Next methods are automatically implemented by code generator */
 	sigc::signal<void, OnNose> signalOnNose;

--- a/modules/nubo_nose/nubo-nose-detector/src/server/interface/nubonosedetector.NuboNoseDetector.kmd.json
+++ b/modules/nubo_nose/nubo-nose-detector/src/server/interface/nubonosedetector.NuboNoseDetector.kmd.json
@@ -97,7 +97,43 @@
 			    "type": "int"
 			}
 		    ]
-		}
+        },
+        {
+          "name": "unsetOverlayedImage",
+          "doc": "Clear the image to be shown over each detected nose. Stops overlaying the noses.",
+          "params": []
+        },
+        {
+          "name": "setOverlayedImage",
+          "doc": "Sets the image to use as overlay on the detected noses.",
+          "params": [
+            {
+              "name": "uri",
+              "doc": "URI where the image is located",
+              "type": "String"
+            },
+            {
+              "name": "offsetXPercent",
+              "doc": "the offset applied to the image, from the X coordinate of the detected nose upper right corner. A positive value indicates right displacement, while a negative value moves the overlaid image to the left. This offset is specified as a percentage of the nose width.\n\nFor example, to cover the detected nose with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the nose´s X coord, +- the nose´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "offsetYPercent",
+              "doc": "the offset applied to the image, from the Y coordinate of the detected nose upper right corner. A positive value indicates up displacement, while a negative value moves the overlaid image down. This offset is specified as a percentage of the nose width.\n\nFor example, to cover the detected nose with the overlaid image, the parameter has to be ``0.0``. Values of ``1.0`` or ``-1.0`` indicate that the image upper right corner will be at the nose´s Y coord, +- the nose´s width.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "widthPercent",
+              "doc": "proportional width of the overlaid image, relative to the width of the detected nose. A value of 1.0 implies that the overlaid image will have the same width as the detected nose. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            },
+            {
+              "name": "heightPercent",
+              "doc": "proportional height of the overlaid image, relative to the height of the detected nose. A value of 1.0 implies that the overlaid image will have the same height as the detected nose. Values greater than 1.0 are allowed, while negative values are forbidden.\n\n.. note::\n\n    The parameter name is misleading, the value is not a percent but a ratio",
+              "type": "float"
+            }
+          ]
+        }
 	    ],	
 	    "events": [
 		"OnNose"

--- a/modules/nubo_nose/nubo-nose-detector/src/server/interface/nubonosedetector.kmd.json
+++ b/modules/nubo_nose/nubo-nose-detector/src/server/interface/nubonosedetector.kmd.json
@@ -1,5 +1,5 @@
 {
   "name": "nubonosedetector",
-  "version": "6.4.02",
+  "version": "6.4.03-dev",
   "kurentoVersion": "^6.0.0"
 }


### PR DESCRIPTION
Hi,

I have added the ability to show an image instead of a rectangle in the detected areas.

Also I have detected a segmentation fault in the nubo_eye filter. I don't know if it is my own problem or a known problem but this patch https://github.com/nubomedia/NUBOMEDIA-VCA/commit/cd7cd9a89665874386beafde8a9ac3f214037830 solves it for me. BTW, the filter only detects one eye, again it could be my own problem.

Please, note that I have updated the project version in all the modules to the next dev version.
